### PR TITLE
Create the initial version of optional_query_cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+coverage
+*.gem
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gemspec

--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,19 @@
+Copyright (C) 2016 Crown copyright (Ministry of Justice)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+OptionalQueryCache
+==================
+
+Drop-in replacement for ActiveRecord::QueryCache that allows
+query-caching to be disabled on specific routes:
+
+```ruby
+get 'healthcheck', to: 'healthcheck#index', disable_query_cache: true
+```
+
+This is particularly useful for routes used to report if the app can
+connect to the database or not (which ActiveRecord::QueryCache would
+normally block by way of a connection error).
+
+Getting started
+---------------
+
+Install the gem:
+
+```ruby
+# Gemfile
+gem 'optional_query_cache', github: 'ministryofjustice/rails-optional_query_cache'
+```
+
+Tell your app to use the OptionalQueryCache middleware instead of
+ActiveRecord::QueryCache:
+
+```ruby
+# config/application.rb
+config.middleware.swap 'ActiveRecord::QueryCache', 'OptionalQueryCache'
+```
+
+Disable query caching on the routes in question:
+
+```ruby
+# config/routes.rb
+get 'healthcheck', to: 'healthcheck#index', disable_query_cache: true
+```

--- a/README.md
+++ b/README.md
@@ -35,4 +35,9 @@ Disable query caching on the routes in question:
 ```ruby
 # config/routes.rb
 get 'healthcheck', to: 'healthcheck#index', disable_query_cache: true
+# or, for multiple routes…
+scope disable_query_cache: true do
+  get 'route1', to: 'route1#index'
+  get 'route2', to: 'route2#index'
+end
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ActiveRecord::QueryCache:
 
 ```ruby
 # config/application.rb
-config.middleware.swap 'ActiveRecord::QueryCache', 'OptionalQueryCache'
+config.middleware.swap 'ActiveRecord::QueryCache', 'OptionalQueryCache::QueryCache'
 ```
 
 Disable query caching on the routes in question:

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,12 @@
+require 'rake'
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
+
+task(:spec).clear
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.verbose = false
+end
+task(:default).prerequisites << task(:spec)
+
+RuboCop::RakeTask.new
+task(:default).prerequisites << task(:rubocop)

--- a/lib/optional_query_cache.rb
+++ b/lib/optional_query_cache.rb
@@ -4,4 +4,14 @@ require 'optional_query_cache/version'
 
 # Rack middleware to allow per-route disabling of ActiveRecord::QueryCache
 class OptionalQueryCache < ActiveRecord::QueryCache
+  def call(env)
+    path_parameters = env['action_dispatch.routes'].recognize_path(
+      env['REQUEST_PATH']
+    )
+    if path_parameters[:disable_query_cache]
+      @app.call(env)
+    else
+      super(env)
+    end
+  end
 end

--- a/lib/optional_query_cache.rb
+++ b/lib/optional_query_cache.rb
@@ -1,0 +1,7 @@
+require 'active_record'
+
+require 'optional_query_cache/version'
+
+# Rack middleware to allow per-route disabling of ActiveRecord::QueryCache
+class OptionalQueryCache < ActiveRecord::QueryCache
+end

--- a/lib/optional_query_cache.rb
+++ b/lib/optional_query_cache.rb
@@ -5,13 +5,20 @@ require 'optional_query_cache/version'
 # Rack middleware to allow per-route disabling of ActiveRecord::QueryCache
 class OptionalQueryCache < ActiveRecord::QueryCache
   def call(env)
-    path_parameters = env['action_dispatch.routes'].recognize_path(
-      env['REQUEST_PATH']
-    )
-    if path_parameters[:disable_query_cache]
+    if path_parameters(env)[:disable_query_cache]
       @app.call(env)
     else
       super(env)
     end
+  end
+
+  private
+
+  def path_parameters(env)
+    env['action_dispatch.routes'].recognize_path(
+      env['REQUEST_PATH']
+    )
+  rescue ActionController::RoutingError
+    {}
   end
 end

--- a/lib/optional_query_cache.rb
+++ b/lib/optional_query_cache.rb
@@ -1,24 +1,2 @@
-require 'active_record'
-
 require 'optional_query_cache/version'
-
-# Rack middleware to allow per-route disabling of ActiveRecord::QueryCache
-class OptionalQueryCache < ActiveRecord::QueryCache
-  def call(env)
-    if path_parameters(env)[:disable_query_cache]
-      @app.call(env)
-    else
-      super(env)
-    end
-  end
-
-  private
-
-  def path_parameters(env)
-    env['action_dispatch.routes'].recognize_path(
-      env['REQUEST_PATH']
-    )
-  rescue ActionController::RoutingError
-    {}
-  end
-end
+require 'optional_query_cache/query_cache'

--- a/lib/optional_query_cache/query_cache.rb
+++ b/lib/optional_query_cache/query_cache.rb
@@ -1,0 +1,24 @@
+require 'active_record'
+
+module OptionalQueryCache
+  # Rack middleware to allow per-route disabling of ActiveRecord::QueryCache
+  class QueryCache < ActiveRecord::QueryCache
+    def call(env)
+      if path_parameters(env)[:disable_query_cache]
+        @app.call(env)
+      else
+        super(env)
+      end
+    end
+
+    private
+
+    def path_parameters(env)
+      env['action_dispatch.routes'].recognize_path(
+        env['REQUEST_PATH']
+      )
+    rescue ActionController::RoutingError
+      {}
+    end
+  end
+end

--- a/lib/optional_query_cache/version.rb
+++ b/lib/optional_query_cache/version.rb
@@ -1,4 +1,6 @@
-class OptionalQueryCache
+require 'active_record'
+
+class OptionalQueryCache < ActiveRecord::QueryCache
   module VERSION #:nodoc:
     MAJOR = 0
     MINOR = 1

--- a/lib/optional_query_cache/version.rb
+++ b/lib/optional_query_cache/version.rb
@@ -1,7 +1,5 @@
-require 'active_record'
-
-class OptionalQueryCache < ActiveRecord::QueryCache
-  module VERSION #:nodoc:
+module OptionalQueryCache
+  class VERSION #:nodoc:
     MAJOR = 0
     MINOR = 1
     PATCH = 0

--- a/lib/optional_query_cache/version.rb
+++ b/lib/optional_query_cache/version.rb
@@ -1,0 +1,9 @@
+class OptionalQueryCache
+  module VERSION #:nodoc:
+    MAJOR = 0
+    MINOR = 1
+    PATCH = 0
+
+    STRING = [MAJOR, MINOR, PATCH].join('.')
+  end
+end

--- a/optional_query_cache.gemspec
+++ b/optional_query_cache.gemspec
@@ -1,0 +1,34 @@
+lib = File.expand_path('../lib/', __FILE__)
+$LOAD_PATH.unshift lib unless $LOAD_PATH.include?(lib)
+
+require 'optional_query_cache/version'
+
+Gem::Specification.new do |s|
+  s.name                  = 'optional_query_cache'
+  s.version               = OptionalQueryCache::VERSION::STRING
+  s.required_ruby_version = '>= 2'
+  s.license               = 'MIT'
+
+  s.homepage          = 'https://github.com/ministryofjustice'
+  s.summary           = 'Disable ActiveRecord::QueryCache for specific routes.'
+  s.description       = 'Rails middleware for disabling ' \
+                        'ActiveRecord::QueryCache on specific routes.'
+
+  s.authors           = [
+    'Ministry of Justice',
+    'Steve Marshall'
+  ]
+  s.email             = 'dev@digital.justice.gov.uk'
+
+  s.files             = %w(Rakefile README.md) + Dir.glob('{lib,spec}/**/*')
+  s.require_path      = 'lib'
+  s.test_files        = Dir['spec/*_spec.rb']
+
+  s.add_dependency 'activerecord', '~> 4'
+
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rspec-rails', '~> 3'
+  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'simplecov-rcov'
+end

--- a/spec/optional_query_cache_spec.rb
+++ b/spec/optional_query_cache_spec.rb
@@ -1,3 +1,4 @@
+require 'action_controller/metal/exceptions'
 require 'active_record'
 require 'rack'
 
@@ -54,6 +55,25 @@ RSpec.describe OptionalQueryCache do
 
     it 'disables query caching for the route' do
       expect(ActiveRecord::Base).not_to receive(:connection)
+      subject.call(env)
+    end
+  end
+
+  context 'with an unrecognised route' do
+    before do
+      allow(env).to receive(:[]).with('action_dispatch.routes').and_raise(
+        ActionController::RoutingError.new('Unrecognised route')
+      )
+    end
+
+    it 'permits query caching' do
+      expect(ActiveRecord::Base).to receive(:connection).and_return(
+        double(
+          'connection',
+          query_cache_enabled: true,
+          enable_query_cache!: nil
+        )
+      )
       subject.call(env)
     end
   end

--- a/spec/optional_query_cache_spec.rb
+++ b/spec/optional_query_cache_spec.rb
@@ -6,7 +6,7 @@ require 'spec_helper'
 
 require 'optional_query_cache'
 
-RSpec.describe OptionalQueryCache do
+RSpec.describe OptionalQueryCache::QueryCache do
   let(:app) { ->(env) { [200, env, 'app'] } }
 
   let :subject do

--- a/spec/optional_query_cache_spec.rb
+++ b/spec/optional_query_cache_spec.rb
@@ -13,10 +13,21 @@ RSpec.describe OptionalQueryCache do
   end
 
   let :env do
-    Rack::MockRequest.env_for('http://example.org')
+    double.tap do |env|
+      allow(env).to receive(:[]).with('REQUEST_PATH').and_return('')
+    end
   end
 
   context 'with a normal route' do
+    before do
+      allow(env).to receive(:[]).with('action_dispatch.routes').and_return(
+        double(
+          'routes',
+          recognize_path: {}
+        )
+      )
+    end
+
     it 'permits query caching' do
       expect(ActiveRecord::Base).to receive(:connection).and_return(
         double(
@@ -25,6 +36,24 @@ RSpec.describe OptionalQueryCache do
           enable_query_cache!: nil
         )
       )
+      subject.call(env)
+    end
+  end
+
+  context 'with disable_query_cache set on the route' do
+    before do
+      allow(env).to receive(:[]).with('action_dispatch.routes').and_return(
+        double(
+          'routes',
+          recognize_path: {
+            disable_query_cache: true
+          }
+        )
+      )
+    end
+
+    it 'disables query caching for the route' do
+      expect(ActiveRecord::Base).not_to receive(:connection)
       subject.call(env)
     end
   end

--- a/spec/optional_query_cache_spec.rb
+++ b/spec/optional_query_cache_spec.rb
@@ -19,6 +19,13 @@ RSpec.describe OptionalQueryCache::QueryCache do
     end
   end
 
+  let :mock_connection do
+    double(
+      'connection',
+      query_cache_enabled: true
+    )
+  end
+
   context 'with a normal route' do
     before do
       allow(env).to receive(:[]).with('action_dispatch.routes').and_return(
@@ -27,16 +34,13 @@ RSpec.describe OptionalQueryCache::QueryCache do
           recognize_path: {}
         )
       )
+      allow(ActiveRecord::Base).to receive(:connection).and_return(
+        mock_connection
+      )
     end
 
     it 'permits query caching' do
-      expect(ActiveRecord::Base).to receive(:connection).and_return(
-        double(
-          'connection',
-          query_cache_enabled: true,
-          enable_query_cache!: nil
-        )
-      )
+      expect(mock_connection).to receive(:enable_query_cache!)
       subject.call(env)
     end
   end
@@ -64,16 +68,13 @@ RSpec.describe OptionalQueryCache::QueryCache do
       allow(env).to receive(:[]).with('action_dispatch.routes').and_raise(
         ActionController::RoutingError.new('Unrecognised route')
       )
+      allow(ActiveRecord::Base).to receive(:connection).and_return(
+        mock_connection
+      )
     end
 
     it 'permits query caching' do
-      expect(ActiveRecord::Base).to receive(:connection).and_return(
-        double(
-          'connection',
-          query_cache_enabled: true,
-          enable_query_cache!: nil
-        )
-      )
+      expect(mock_connection).to receive(:enable_query_cache!)
       subject.call(env)
     end
   end

--- a/spec/optional_query_cache_spec.rb
+++ b/spec/optional_query_cache_spec.rb
@@ -1,0 +1,31 @@
+require 'active_record'
+require 'rack'
+
+require 'spec_helper'
+
+require 'optional_query_cache'
+
+RSpec.describe OptionalQueryCache do
+  let(:app) { ->(env) { [200, env, 'app'] } }
+
+  let :subject do
+    described_class.new(app)
+  end
+
+  let :env do
+    Rack::MockRequest.env_for('http://example.org')
+  end
+
+  context 'with a normal route' do
+    it 'permits query caching' do
+      expect(ActiveRecord::Base).to receive(:connection).and_return(
+        double(
+          'connection',
+          query_cache_enabled: true,
+          enable_query_cache!: nil
+        )
+      )
+      subject.call(env)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,5 @@
+require 'simplecov'
+require 'simplecov-rcov'
+SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
+SimpleCov.minimum_coverage 100
+SimpleCov.start


### PR DESCRIPTION
This is a drop-in replacement for ActiveRecord::QueryCache that allows query-caching to be disabled on specific routes.

This is particularly useful for routes used to report if the app can connect to the database or not (which ActiveRecord::QueryCache would normally block by way of a connection error).

This PR is identical to #2, but with `fixup` commits rebased properly. (Master has been rebased to remove the merge of #2.)
